### PR TITLE
Move ROS 2 Threat model before demo in preliminary program

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,11 +125,12 @@ Starting with the 2019 edition, ROSCon has a pre-conference workshops half-day, 
           <h1>Preliminary Program</h1>
 <ul>
   <li>Introduction</li>
+  <li>ROS 2 Threat Model</li>
   <li>ROS 2 Demo Presentation</li>
   <li>Alias Discovery Tool</li>
   <li>Harden using SROS 2</li>
   <li>Node sandboxing</li>
-  <li>ROS 2 Threat Model</li>
+  <li>Conclusion</li>
 </ul>
 
 <!--

--- a/program.html
+++ b/program.html
@@ -1,11 +1,12 @@
 <h1>Preliminary Program</h1>
 <ul>
   <li>Introduction</li>
+  <li>ROS 2 Threat Model</li>
   <li>ROS 2 Demo Presentation</li>
   <li>Alias Discovery Tool</li>
   <li>Harden using SROS 2</li>
   <li>Node sandboxing</li>
-  <li>ROS 2 Threat Model</li>
+  <li>Conclusion</li>
 </ul>
 
 <!--

--- a/src/_posts/2019-06-04-program.md
+++ b/src/_posts/2019-06-04-program.md
@@ -7,11 +7,12 @@ fa-icon: bookmark
 
 # Preliminary Program
 * Introduction
+* ROS 2 Threat Model
 * ROS 2 Demo Presentation
 * Alias Discovery Tool
 * Harden using SROS 2
 * Node sandboxing
-* ROS 2 Threat Model
+* Conclusion
 
 <!--
 * **Lunch Break \| 13:30 - 14:30**


### PR DESCRIPTION
### Changes
* Move `ROS 2 Threat Model` before `ROS 2 Demo Presentation`
* Add `Conclusion` to end of `Preliminary Program`

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>